### PR TITLE
Fix k3d log issue

### DIFF
--- a/.vscode/scripts/runtime/k3d/configure_controlplane.sh
+++ b/.vscode/scripts/runtime/k3d/configure_controlplane.sh
@@ -36,7 +36,7 @@ then
       -e "HTTP_PROXY=$HTTP_PROXY@server:0" \
       -e "HTTPS_PROXY=$HTTPS_PROXY@server:0" \
       --volume $ROOT_DIRECTORY/deploy/runtime/k3d/volume:/mnt/data@server:0 \
-      -e "NO_PROXY=localhost@server:0"
+      -e "NO_PROXY=$NO_PROXY@server:0"
   else
     echo "Creating cluster without proxy configuration"
     k3d cluster create cluster \


### PR DESCRIPTION
# Description

ADO-11205

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
