### PR TITLE
Introduce dummy workflows for VADF lifecycle preparation

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build Docker Image for single arch
+
+on:
+  workflow_call:
+
+
+jobs:
+  dummy-job:
+    name: "Empty"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Hello World
+        run: echo "Hello World"

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build multiarch image
+
+on:
+  workflow_dispatch:
+  push:
+    # Run only on branches/commits and not tags
+    branches:
+      - main
+
+jobs:
+  build-image-multiarch:
+    uses: ./.github/workflows/build-docker-image.yml

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -6,7 +6,7 @@
 |bottle|0.12.23|MIT|
 |certifi|2022.12.7|Mozilla Public License 2.0|
 |cfgv|3.3.1|MIT|
-|charset-normalizer|2.1.1|MIT|
+|charset-normalizer|3.0.1|MIT|
 |colorama|0.4.6|BSD|
 |conan|1.55.0|MIT|
 |cpplint|1.6.1|New BSD|
@@ -15,11 +15,11 @@
 |fasteners|0.18|Apache 2.0|
 |filelock|3.9.0|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.12|MIT|
+|identify|2.5.15|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.2|New BSD|
-|MarkupSafe|2.1.1|New BSD|
+|MarkupSafe|2.1.2|New BSD|
 |node-semver|0.6.1|MIT|
 |nodeenv|1.7.0|BSD|
 |patch-ng|1.17.4|MIT|
@@ -30,12 +30,12 @@
 |PyJWT|2.6.0|MIT|
 |python-dateutil|2.8.2|Apache 2.0<br/>BSD|
 |PyYAML|6.0|MIT|
-|requests|2.28.1|Apache 2.0|
+|requests|2.28.2|Apache 2.0|
 |setuptools|58.1.0|MIT|
 |six|1.16.0|MIT|
 |toml|0.10.2|MIT|
 |tqdm|4.64.1|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
-|urllib3|1.26.13|MIT|
+|urllib3|1.26.14|MIT|
 |virtualenv|20.17.1|MIT|
 ## Workflows
 | Dependency | Version | License |


### PR DESCRIPTION
# Description

Add dummy workflows to prepare the repo for the VADF lifecycle introduction.

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#12311

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
