### PR TITLE
Vspec link in AppManifest

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: eclipse-velocitas/license-check
-          ref: v1.2.0
+          ref: v1.2.1
           path: .github/actions/license-check
 
       - name: Run License Checker

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -15,7 +15,7 @@
 |fasteners|0.18|Apache 2.0|
 |filelock|3.9.0|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.15|MIT|
+|identify|2.5.17|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.2|New BSD|

--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -4,6 +4,7 @@
         "Port": -1,
         "DAPR_GRPC_PORT": 50001,
         "Dockerfile": "./app/Dockerfile",
+        "vspec": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
         "dependencies": {
             "services": [
                 {

--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -4,7 +4,9 @@
         "Port": -1,
         "DAPR_GRPC_PORT": 50001,
         "Dockerfile": "./app/Dockerfile",
-        "vspec": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+        "vehicle_model": {
+            "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json"
+        },
         "dependencies": {
             "services": [
                 {

--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -4,7 +4,7 @@
         "Port": -1,
         "DAPR_GRPC_PORT": 50001,
         "Dockerfile": "./app/Dockerfile",
-        "vehicle_model": {
+        "VehicleModel": {
             "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json"
         },
         "dependencies": {


### PR DESCRIPTION
# Description
This PR adds a link to Vspec to AppManifest.json.

<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

[AB#12509](https://softwaredefinedvehicle.visualstudio.com/SoftwareDefinedVehicle/_boards/board/t/DEV/Backlog%20items/?workitem=12509)

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
