### PR TITLE
Fix: Revert mount to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
 	],
 	// workaround for the devcontainer features
 	"overrideCommand": false,
+	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"[cpp]": {


### PR DESCRIPTION
# Description
The PR fixes k3d runtime by reverting mount to devcontainer
<!--
Please explain the changes you've made.
-->

## Azure DevOps PBI/Task reference

<!--
We strive to have all PR being opened based on an Azure DevOps PBI/Task.
Please reference the PBI/Task this PR will close:
-->

AB#_[PBI/Task number]_

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
