### PR TITLE
Pass on GITHUB_API_TOKEN from host to container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
 		"--security-opt",
 		"seccomp=unconfined"
 	],
+	"containerEnv": {
+		"GITHUB_API_TOKEN": "${localEnv:GITHUB_API_TOKEN}"
+	},
 	// workaround for the devcontainer features
 	"overrideCommand": false,
 	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -18,7 +18,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.0.4"
+            "version": "v1.0.5"
         }
     ],
     "variables": {

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -15,7 +15,7 @@
 |fasteners|0.18|Apache 2.0|
 |filelock|3.9.0|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.17|MIT|
+|identify|2.5.18|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.2|New BSD|


### PR DESCRIPTION
# Description

Enable passing env variable GITHUB_API_TOKEN from the host env to container env (solving/limiting GitHub's rate limiting issues)

## Azure DevOps PBI/Task reference

AB#_[PBI/Task number]_

## Checklist
* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
