### PR TITLE
Bugfix: Overwrite vehicleAppPort and fix MQTT path in k3d runtime

### DIFF
--- a/.velocitas.json
+++ b/.velocitas.json
@@ -2,7 +2,7 @@
     "packages": [
         {
             "name": "devenv-runtimes",
-            "version": "v1.0.1"
+            "version": "v1.0.2"
         },
         {
             "name": "devenv-github-workflows",
@@ -23,6 +23,7 @@
         "appManifestPath": "app/AppManifest.json",
         "githubRepoId": "eclipse-velocitas/vehicle-app-cpp-template",
         "appExecutionPlatforms": "linux/amd64",
-        "generatedModelPath": "./app/vehicle_model"
+        "generatedModelPath": "./app/vehicle_model",
+        "vehicleAppPort": -1
     }
 }


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

dapr app port needs to be explicitly set to -1 to work with the C++ SDK and a bug in the devenv-runtimes package is fixed to allow startup of apps in the k3d runtime.

## Issue ticket number and link

Fixes #45 

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [x] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
