### PR TITLE
Update depenency to avoid CVE-2022-4904

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.2
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.3
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE
 ENV REINSTALL_CMAKE_VERSION_FROM_SOURCE="${REINSTALL_CMAKE_VERSION_FROM_SOURCE:-none}"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,7 +38,7 @@ jobs:
   build-image:
     name: "Building image (${{ matrix.component.name }})"
     runs-on: ubuntu-latest
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.2
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.3
     strategy:
       matrix:
         component: ${{ fromJson(inputs.deployment-matrix-str) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.2
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.3
     name: "Build, Test and Lint"
     steps:
       - name: Checkout repository

--- a/.github/workflows/ensure-lifecycle.yml
+++ b/.github/workflows/ensure-lifecycle.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   check-sync:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.2
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1.3
     name: Are files in sync?
 
     steps:

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v2.0.7"
+            "version": "v2.0.9"
         },
         {
             "name": "devenv-github-templates",
@@ -14,7 +14,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.1.8"
+            "version": "v1.1.9"
         }
     ],
     "variables": {

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -13,17 +13,17 @@
 |distlib|0.3.6|Python Software Foundation License|
 |distro|1.7.0|Apache 2.0|
 |fasteners|0.18|Apache 2.0|
-|filelock|3.12.0|The Unlicense (Unlicense)|
+|filelock|3.12.2|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
 |identify|2.5.24|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.2|New BSD|
-|MarkupSafe|2.1.2|New BSD|
+|MarkupSafe|2.1.3|New BSD|
 |node-semver|0.6.1|MIT|
 |nodeenv|1.8.0|BSD|
 |patch-ng|1.17.4|MIT|
-|platformdirs|3.5.1|MIT|
+|platformdirs|3.8.0|MIT|
 |pluginbase|1.0.1|BSD|
 |pre-commit|2.20.0|MIT|
 |Pygments|2.15.1|Simplified BSD|
@@ -36,7 +36,7 @@
 |toml|0.10.2|MIT|
 |tqdm|4.65.0|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.16|MIT|
-|virtualenv|20.23.0|MIT|
+|virtualenv|20.23.1|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -48,18 +48,19 @@ The C++ dependencies should be normally also listed in the auto-generated notice
 Due to the limited Conan support of the Pivotal License Finder currently used in our [License Check](https://github.com/eclipse-velocitas/license-check),
 they are given here (manually added) for time being:
 
+
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |abseil|20220623.0|Apache 2.0|
-|c-ares|1.18.1|c-ares (MIT-style)|
-|cpr|1.9.3|MIT|
+|c-ares|1.19.1|c-ares (MIT-style)|
+|cpr|1.10.1|MIT|
 |fmt|9.1.0|MIT|
 |googleapis|cci.20221108|Apache 2.0|
 |grpc|1.50.1|Apache 2.0|
 |grpc-proto|cci.20220627|Apache 2.0|
-|libcurl|7.87.0|CURL|
+|libcurl|8.1.2|CURL|
 |nlohmann_json|3.11.2|MIT|
-|openssl|1.1.1t|OpenSSL License AND SSLeay License|
+|openssl|1.1.1u|OpenSSL License AND SSLeay License|
 |paho-mqtt-c|1.3.9|EPL 2.0 AND EDL 1.0|
 |paho-mqtt-cpp|1.2.0|EPL 1.0 AND EDL 1.0|
 |protobuf|3.21.9|Google License|

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax = docker/dockerfile:1.2
 
-FROM ghcr.io/eclipse-velocitas/vehicle-app-cpp-sdk:v0.3.1 as builder
+FROM ghcr.io/eclipse-velocitas/vehicle-app-cpp-sdk:v0.3.2 as builder
 
 RUN apk update && \
     apk add ninja && \


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->

# Description

Update packages:
* devenv-github-workflows@v2.0.9
* devenv-devcontainer-setup@v1.1.9
* devcontainer-base-image@v1.0.3
* cpp-sdk@v0.3.2

Fix some security issues:
* CVE-2022-4904
* CVE-2023-27536
* CVE-2023-27535
* CVE-2023-27538
* CVE-2023-0466
* CVE-2023-0464
* CVE-2023-0465


## Issue ticket number and link

ADO#15373

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [x] Release workflow is passing
