### PR TITLE
Integrate mock service

### DIFF
--- a/.velocitas.json
+++ b/.velocitas.json
@@ -2,7 +2,7 @@
     "packages": [
         {
             "name": "devenv-runtimes",
-            "version": "v1.1.1"
+            "version": "v2.0.0"
         },
         {
             "name": "devenv-github-workflows",

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -4,18 +4,18 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |bottle|0.12.25|MIT|
-|certifi|2023.5.7|Mozilla Public License 2.0|
+|certifi|2023.7.22|Mozilla Public License 2.0|
 |cfgv|3.3.1|MIT|
 |charset-normalizer|3.2.0|MIT|
 |colorama|0.4.6|BSD|
 |conan|1.58.0|MIT|
 |cpplint|1.6.1|New BSD|
-|distlib|0.3.6|Python Software Foundation License|
+|distlib|0.3.7|Python Software Foundation License|
 |distro|1.7.0|Apache 2.0|
 |fasteners|0.18|Apache 2.0|
 |filelock|3.12.2|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.24|MIT|
+|identify|2.5.26|MIT|
 |idna|3.4|BSD|
 |Jinja2|3.1.2|New BSD|
 |lxml|4.9.3|New BSD|
@@ -23,11 +23,11 @@
 |node-semver|0.6.1|MIT|
 |nodeenv|1.8.0|BSD|
 |patch-ng|1.17.4|MIT|
-|platformdirs|3.8.1|MIT|
+|platformdirs|3.9.1|MIT|
 |pluginbase|1.0.1|BSD|
 |pre-commit|2.20.0|MIT|
 |Pygments|2.15.1|Simplified BSD|
-|PyJWT|2.7.0|MIT|
+|PyJWT|2.8.0|MIT|
 |python-dateutil|2.8.2|Apache 2.0<br/>BSD|
 |PyYAML|6.0|MIT|
 |requests|2.31.0|Apache 2.0|
@@ -36,7 +36,7 @@
 |toml|0.10.2|MIT|
 |tqdm|4.65.0|MIT<br/>Mozilla Public License 2.0 (MPL 2.0)|
 |urllib3|1.26.16|MIT|
-|virtualenv|20.23.1|MIT|
+|virtualenv|20.24.2|MIT|
 ## Workflows
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

This PR upgrades the `devenv-runtimes` package to include the new mock service as default service. This replaces seat-service and feedercan as default services.

## Issue ticket number and link

ADO_15873

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [x] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
