### PR TITLE
fix: App container build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1
+FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.2
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE
 ENV REINSTALL_CMAKE_VERSION_FROM_SOURCE="${REINSTALL_CMAKE_VERSION_FROM_SOURCE:-none}"

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
   build-image:
     name: "Building image (${{ inputs.app_name }})"
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.2
     env:
       APP_NAME: ${{ inputs.app_name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.2
     name: "Build, Test and Lint"
     steps:
       - name: Checkout repository

--- a/.github/workflows/ensure-lifecycle.yml
+++ b/.github/workflows/ensure-lifecycle.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   check-sync:
     runs-on: ubuntu-22.04
-    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.1
+    container: ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.2
     name: Are files in sync?
 
     steps:

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "devenv-github-workflows",
-            "version": "v3.1.0"
+            "version": "v4.0.0"
         },
         {
             "name": "devenv-github-templates",
@@ -14,7 +14,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v1.3.0"
+            "version": "v1.4.0"
         }
     ],
     "variables": {

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -12,7 +12,7 @@
 |cpplint|1.6.1|New BSD|
 |distlib|0.3.7|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
-|fasteners|0.18|Apache 2.0|
+|fasteners|0.19|Apache 2.0|
 |filelock|3.12.4|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
 |identify|2.5.29|MIT|

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,35 +14,33 @@
 
 # syntax = docker/dockerfile:1.2
 
-FROM ghcr.io/eclipse-velocitas/vehicle-app-cpp-sdk:v0.3.3 as builder
+FROM ghcr.io/eclipse-velocitas/vehicle-app-cpp-sdk/app-builder:v0.4 as builder
 
 RUN apk update && \
-    apk add ninja && \
-    apk add cmake && \
-    apk add clang-extra-tools && \
-    apk add python3 && \
-    apk add py3-pip && \
-    apk add build-base && \
-    apk add linux-headers && \
-    apk add perl && \
-    apk add bash && \
-    apk add git && \
-    pip3 install "conan==1.60.2"
+    apk add jq && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
-COPY . /app
+COPY . /workspace
 
 RUN --mount=type=cache,target=/root/.conan
 
-RUN cd /app && \
+# FIXME: For build tooling we only need "devenv-devcontainer-setup", we should be able to
+# filter this without manual jq intervention...
+RUN mv /workspace/.velocitas.json /workspace/.velocitas_org.json && \
+    cat /workspace/.velocitas_org.json | jq 'del(.packages[] | select(.name != "devenv-devcontainer-setup"))' > /workspace/.velocitas.json
+
+WORKDIR /workspace
+
+RUN velocitas init -f -v && \
     ./install_dependencies.sh -r && \
     ./build.sh -r -t app --static
 
-RUN strip /app/build/bin/app
+RUN strip /workspace/build/bin/app
 
 # Runner stage, to copy the executable
 FROM scratch
 
-COPY --from=builder /app/build/bin/app /dist/app
+COPY --from=builder /workspace/build/bin/app /dist/app
 
 WORKDIR /tmp
 WORKDIR /dist

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-vehicle-app-sdk/0.4.0
+vehicle-app-sdk/0.4.1
 
 [generators]
 cmake


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

PR fixes the app container build.
The builder image was missing Velocitas CLI in order to run lifecycle management to generate required pieces of code.

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [x] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [x] Vehicle App can process MQTT messages and call the seat service
* [x] Vehicle App can be deployed to local K3D and is running
* [x] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [x] Devcontainer can be opened successfully
* [x] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
