### PR TITLE
Rename component vehicle-model-lifecycle to vehicle-signal-interface

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -267,7 +267,7 @@
 			"label": "(Re-)generate vehicle model",
 			"detail": "(Re-)generates the vehicle model from source files specified in the AppManifest.",
 			"type": "shell",
-			"command": "velocitas exec vehicle-model-lifecycle download-vspec && velocitas exec vehicle-model-lifecycle generate-model",
+			"command": "velocitas exec vehicle-signal-interface download-vspec && velocitas exec vehicle-signal-interface generate-model",
 			"group": "none",
 			"presentation": {
 				"reveal": "always",

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -28,7 +28,7 @@
 |pre-commit|3.5.0|MIT|
 |pygments|2.17.2|Simplified BSD|
 |PyJWT|2.8.0|MIT|
-|python-dateutil|2.8.2|Apache 2.0<br/>BSD|
+|python-dateutil|2.9.0.post0|Apache 2.0<br/>BSD|
 |PyYAML|6.0.1|MIT|
 |requests|2.31.0|Apache 2.0|
 |setuptools|58.1.0|MIT|


### PR DESCRIPTION
This PR renames the component call vehicle-model-lifecycle to vehicle-signal-interface

could only be merged after https://github.com/eclipse-velocitas/devenv-devcontainer-setup/pull/55 and new tag