### PR TITLE
[Bugfix #72] Fix app deployment in Kanto runtime

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 vehicle-model/generated
-vehicle-app-sdk/0.4.2
+vehicle-app-sdk/0.4.3
 
 [generators]
 cmake


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

Fixes #72 which was caused by the lack of the [C++ SDK](https://github.com/eclipse-velocitas/vehicle-app-cpp-sdk) to handle addresses of communication partners of the app given in URL style, e.g. `mqtt://localhost:12345`. This is fixed by [C++ SDK release v0.4.3](https://github.com/eclipse-velocitas/vehicle-app-cpp-sdk/releases/tag/v0.4.3), which is "pulled in" by this PR.

## Issue ticket number and link

#72

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
