### PR TITLE
Add support for VSS 4.0

### DIFF
--- a/.velocitas-lock.json
+++ b/.velocitas-lock.json
@@ -1,20 +1,8 @@
 {
-    "packages": [
-        {
-            "repo": "devenv-runtimes",
-            "version": "v3.1.0"
-        },
-        {
-            "repo": "devenv-github-workflows",
-            "version": "v4.1.4"
-        },
-        {
-            "repo": "devenv-github-templates",
-            "version": "v1.0.3"
-        },
-        {
-            "repo": "devenv-devcontainer-setup",
-            "version": "v2.1.0"
-        }
-    ]
+    "packages": {
+        "devenv-runtimes": "v3.1.0",
+        "devenv-github-workflows": "v6.0.0",
+        "devenv-github-templates": "v1.0.4",
+        "devenv-devcontainer-setup": "v2.1.0"
+    }
 }

--- a/.velocitas-lock.json
+++ b/.velocitas-lock.json
@@ -1,0 +1,20 @@
+{
+    "packages": [
+        {
+            "repo": "devenv-runtimes",
+            "version": "v3.1.0"
+        },
+        {
+            "repo": "devenv-github-workflows",
+            "version": "v4.1.4"
+        },
+        {
+            "repo": "devenv-github-templates",
+            "version": "v1.0.3"
+        },
+        {
+            "repo": "devenv-devcontainer-setup",
+            "version": "v2.1.0"
+        }
+    ]
+}

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -1,22 +1,10 @@
 {
-    "packages": [
-        {
-            "name": "devenv-runtimes",
-            "version": "v3.1.0"
-        },
-        {
-            "name": "devenv-github-workflows",
-            "version": "v6.0.0"
-        },
-        {
-            "name": "devenv-github-templates",
-            "version": "v1.0.4"
-        },
-        {
-            "name": "devenv-devcontainer-setup",
-            "version": "v2.1.0"
-        }
-    ],
+    "packages": {
+        "devenv-runtimes": "v3.1.0",
+        "devenv-github-workflows": "v6.0.0",
+        "devenv-github-templates": "v1.0.4",
+        "devenv-devcontainer-setup": "v2.1.0"
+    },
     "variables": {
         "language": "cpp",
         "repoType": "app",
@@ -24,5 +12,5 @@
         "githubRepoId": "eclipse-velocitas/vehicle-app-cpp-template",
         "vehicleAppPort": -1
     },
-    "cliVersion": "v0.8.0"
+    "cliVersion": "v0.9.0"
 }

--- a/.velocitas.json
+++ b/.velocitas.json
@@ -2,7 +2,7 @@
     "packages": [
         {
             "name": "devenv-runtimes",
-            "version": "v3.0.0"
+            "version": "v3.1.0"
         },
         {
             "name": "devenv-github-workflows",
@@ -14,7 +14,7 @@
         },
         {
             "name": "devenv-devcontainer-setup",
-            "version": "v2.0.0"
+            "version": "v2.1.0"
         }
     ],
     "variables": {
@@ -24,5 +24,5 @@
         "githubRepoId": "eclipse-velocitas/vehicle-app-cpp-template",
         "vehicleAppPort": -1
     },
-    "cliVersion": "v0.7.0"
+    "cliVersion": "v0.8.0"
 }

--- a/app/AppManifest.json
+++ b/app/AppManifest.json
@@ -5,7 +5,7 @@
         {
             "type": "vehicle-signal-interface",
             "config": {
-                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v3.0/vss_rel_3.0.json",
+                "src": "https://github.com/COVESA/vehicle_signal_specification/releases/download/v4.0/vss_rel_4.0.json",
                 "datapoints":
                 {
                     "required": [


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description
This adds the ability to specify a list of unit files for model generation with vss-tools. It is needed to support VSS 4.0.
<!--
Please explain the changes you've made.
-->

## Issue ticket number and link

<!--
Please provide a reference to the issue or the bug that you filed for the issue you are solving.
-->

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with dapr run and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local K3D and is running
* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.
* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
