### PR TITLE
Fix high cpu load due to recurring prune job in SDK

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -13,12 +13,12 @@
 |distlib|0.3.8|Python Software Foundation License|
 |distro|1.8.0|Apache 2.0|
 |fasteners|0.19|Apache 2.0|
-|filelock|3.13.1|The Unlicense (Unlicense)|
+|filelock|3.13.3|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
 |identify|2.5.35|MIT|
 |idna|3.6|BSD|
 |Jinja2|3.1.3|New BSD|
-|lxml|5.1.0|New BSD|
+|lxml|5.2.1|New BSD|
 |MarkupSafe|2.1.5|New BSD|
 |node-semver|0.6.1|MIT|
 |nodeenv|1.8.0|BSD|

--- a/app/src/Launcher.cpp
+++ b/app/src/Launcher.cpp
@@ -18,18 +18,21 @@
 #include "sdk/Logger.h"
 
 #include <csignal>
+#include <memory>
+
+std::unique_ptr<example::SampleApp> myApp;
 
 void signal_handler(int sig) {
-    velocitas::logger().error("App terminated due to: Signal {}", sig);
-    exit(-1);
+    velocitas::logger().info("App terminated due to: Signal {}", sig);
+    myApp->stop();
 }
 
 int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
 
-    example::SampleApp myApp;
+    myApp = std::make_unique<example::SampleApp>();
     try {
-        myApp.run();
+        myApp->run();
     } catch (const std::exception& e) {
         velocitas::logger().error("App terminated due to: {}", e.what());
     } catch (...) {

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 vehicle-model/generated
-vehicle-app-sdk/0.5.0
+vehicle-app-sdk/fix_high_cpu_load
 
 [generators]
 cmake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 vehicle-model/generated
-vehicle-app-sdk/fix_high_cpu_load
+vehicle-app-sdk/0.5.1
 
 [generators]
 cmake


### PR DESCRIPTION
<!-- This file is maintained by velocitas CLI, do not modify manually. Change settings in .velocitas.json -->
# Description

Fixes the high CPU load issue of a running app, caused by an issue in the [C++ SDK](https://github.com/eclipse-velocitas/vehicle-app-cpp-sdk/pull/89).

## Issue ticket number and link

none

## Checklist

<!--
Check item, if activities have been performed as part of this PR or delete, if not relevant.
-->

* [ ] Vehicle App can be started with native runtime and is connecting to vehicle data broker
* [ ] Vehicle App can process MQTT messages and call the seat service
* [ ] Vehicle App can be deployed to local Kanto runtime and is running

* [ ] Created/updated tests, if necessary. Code Coverage percentage on new code shall be >= 70%.

* [ ] Extended the documentation in Velocitas repo
* [ ] Extended the documentation in README.md

* [ ] Devcontainer can be opened successfully
* [ ] Devcontainer can be opened successfully behind a corporate proxy
* [ ] Devcontainer can be re-built successfully

* [ ] Release workflow is passing
