### PR TITLE
Use correct targetplatform

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax = docker/dockerfile:1.2
 
-FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.3 as builder
+FROM  --platform=$TARGETPLATFORM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.3 as builder
 
 COPY . /workspace
 


### PR DESCRIPTION
Based on mail on velocitas-dev (see below)


Similar setup already used in
https://github.com/eclipse-velocitas/vehicle-app-python-template/blob/main/app/Dockerfile

When testing with  `--platform=linux/arm64` I did not notice any problems using `scratch` in the last step, and for scratch platform should not matter right, it just copies what we have from previous step, or? 

`FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12 as runner`


## Tests performed

Built locally with platform flag on a Debian VM for arm64

```
sudo apt-get install qemu binfmt-support qemu-user-static
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
docker build -f app/Dockerfile --progress=plain --platform=linux/arm64 -t ex3:latest .
docker image inspect ex3:latest | grep Arch
```

* [X] Setup has been tested on https://github.com/erikbosch/vehicle-example-app3


## Original mail

```

Hi Velocitas-dev Team,

_We found a maybe a minor issue in the Dockerfile when building it for arm64 machines.

Background:
We are creating a POC using the vehicle-app-cpp-template.
Everything worked great when we built the docker images in our host machine (amd64) and deployed it in ubuntu test machine (amd64).
However, when we built the docker image for arm64 and still using our host machine (amd64) and to be deployed in our edge devices (arm64).
The final image is still in amd64.

This is how docker build the apps:
$ cd vehicle-app-cpp-template/app
$ docker build -f app/Dockerfile --progress=plain --build-arg TARGETPLATFORM=linux/arm64 -t localhost:12345/app-seat-adjuster:0.0.1 .

After building it we docker image inspect the docker image.: 
$ docker image inspect localhost:12345/app-seat-adjuster:0.0.1 | grep Arch
$ "Architecture": "amd64",

We fixed it by modifying cd vehicle-app-cpp-template/app/Dockerfile.
# FROM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.3 as builder
FROM --platform=$TARGETPLATFORM ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.3 as builder
and
# FROM --platform=$TARGETPLATFORM scratch as runner
FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12 as runner

Note:
•	We did not use scratch since it will still default to linux/amd64 even supplying --platform=linux/arm64

After this minor fix. We can now successfully deploy it with our edge devices (arm64).

Does our Dockerfile changes is correct way to go forward or do you recommend another way to build docker(arm64) images using host(amd64)?

Your response is highly appreciated.

Thank you,_ 

```

