### PR TITLE
Add regular builds to ensure lifecycle and check license

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -26,6 +26,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   check-licenses:

--- a/.github/workflows/ensure-lifecycle.yml
+++ b/.github/workflows/ensure-lifecycle.yml
@@ -23,6 +23,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   check-sync:


### PR DESCRIPTION
_Draft only - I never learn where the source of the files are :-)_

We use minor versions of base images,
like ghcr.io/eclipse-velocitas/devcontainer-base-images/cpp:v0.3 In patched versions like v0.3.X we may change dependencies and/or workflows, which can cause some checks here to fail. By running regularly we will hopefully catch that before any user experience it.
