### PR TITLE
Update license file regression

### DIFF
--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -15,7 +15,7 @@
 |fasteners|0.19|Apache 2.0|
 |filelock|3.15.4|The Unlicense (Unlicense)|
 |gcovr|5.2|BSD|
-|identify|2.5.36|MIT|
+|identify|2.6.0|MIT|
 |idna|3.7|BSD|
 |jinja2|3.1.4|BSD|
 |lxml|5.2.2|New BSD|


### PR DESCRIPTION
I noticed that license file is out of date again so we have a regression on main. Sort of expected as we have "soft" dependencies here and there, i.e. we may get new patches in subsequent builds even if nothing change in this repo.

In https://github.com/eclipse-velocitas/devenv-github-workflows/pull/62 it is proposed to run license check regularly to detect regressions quickly.